### PR TITLE
参照用クラスを通してオブジェクトにアクセスするように修正

### DIFF
--- a/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Res/ConfigrationImageGenSystem.prefab
+++ b/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Res/ConfigrationImageGenSystem.prefab
@@ -19,6 +19,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4173079658851044}
+  - component: {fileID: 114652866730170236}
   m_Layer: 0
   m_Name: ConfigrationImageGenSystem
   m_TagString: Untagged
@@ -308,6 +309,20 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+--- !u!114 &114652866730170236
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1025982004082456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 37efaca9a96aa4162b124718bc310ba6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Version: {fileID: 114970132978686348}
+  VersionFormat: Ver {0}
+  Camera: {fileID: 20463187276955380}
 --- !u!114 &114805897749678650
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Scripts/Editor/AutoIconBuilder.cs
+++ b/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Scripts/Editor/AutoIconBuilder.cs
@@ -26,17 +26,15 @@ public class AutoIconBuilder : IPreprocessBuildWithReport
     public static void GenerateConfigrationImage()
     {
         // Icon を生成。まずは元となるPrefabを読みこんでその中身を変える
-        GameObject iconGenPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(configImagePrefabPath);
-        GameObject iconGen = Object.Instantiate(iconGenPrefab);
+        var iconGenPrefab = AssetDatabase.LoadAssetAtPath<GenSystemPrefab>(configImagePrefabPath);
+        var iconGen = Object.Instantiate(iconGenPrefab);
 
         // バージョン番号
-        var texts = iconGen.GetComponentsInChildren<Text>();
-        string verStr = "Ver " + Application.version;
-        Assert.IsTrue(texts[1].gameObject.name == "Version"); // 念のため確認
-        texts[1].text = verStr;
+        string verStr = string.Format(iconGen.VersionFormat, Application.version);
+        iconGen.Version.text = verStr;
 
         // RenderTexture に焼き込んだ画像をTexture2Dにする
-        Camera camera = iconGen.GetComponentInChildren<Camera>();
+        Camera camera = iconGen.Camera;
         camera.Render();
         RenderTexture original = RenderTexture.active;
         RenderTexture.active = camera.targetTexture;
@@ -55,7 +53,7 @@ public class AutoIconBuilder : IPreprocessBuildWithReport
 
         // 後片付け
         Object.DestroyImmediate(newTexture);
-        Object.DestroyImmediate(iconGen);
+        Object.DestroyImmediate(iconGen.gameObject);
 
         AssetDatabase.Refresh();
     }

--- a/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Scripts/GenSystemPrefab.cs
+++ b/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Scripts/GenSystemPrefab.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+public class GenSystemPrefab : MonoBehaviour
+{
+    public Text Version = null;
+    public string VersionFormat = "Ver {0}";
+    public Camera Camera = null;
+}

--- a/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Scripts/GenSystemPrefab.cs.meta
+++ b/UnityAutoIconBuilder/Assets/UnityAutoIconBuilder/Scripts/GenSystemPrefab.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37efaca9a96aa4162b124718bc310ba6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<img width="378" alt="2019-01-06 8 09 14" src="https://user-images.githubusercontent.com/7017772/50730198-b452e000-118a-11e9-968a-07d59bef459e.png">

撮影用プレハブにクラスを一つ追加しました。
Versionの取得部分について、従来はTextコンポーネントが2番目かつ"Version"という命名という条件でしたが、利用者がプレハブの内容を変更する際に混乱を招くと考えました。
参照用のクラスを用意すれば利用する際に分かりやすいかと思います。

バージョンフォーマットも固定だったので変更可能にしました。

また今回の変更を通じてライブラリ事態の振る舞いは変わっていません(ビルドして確認済み)。